### PR TITLE
kbc: Modify to attest with keybroker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "kbs-types"
 version = "0.4.0"
-source = "git+https://github.com/virtee/kbs-types#90b13bb023c5805d82cc3206fab9c8e57f61746f"
+source = "git+https://github.com/tylerfanelli/kbs-types?branch=snp_mods#80b207b5dd0a9754e59a0a81a2a3625a55ca3f6d"
 dependencies = [
  "serde",
  "serde_json",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "reference-kbc"
 version = "0.1.0"
-source = "git+https://github.com/stefano-garzarella/reference-kbc#8bf78559147907f500953a08af2b77a4945f1e53"
+source = "git+https://github.com/tylerfanelli/reference-kbc?branch=keybroker#c6d4e199d086463dd5cfd2238d31a416249536a9"
 dependencies = [
  "anyhow",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = { version = "0.4.17", features = ["max_level_info", "release_max_level_inf
 packit = { git = "https://github.com/coconut-svsm/packit", version = "0.1.0" }
 aes-gcm = { version = "0.10.3", default-features = false, features = ["aes", "alloc"] }
 rand_chacha = { version = "0.3.1", default-features = false, optional = true}
-reference-kbc = { git = "https://github.com/stefano-garzarella/reference-kbc", version = "0.1.0", default-features = false, features = ["alloc"], optional = true }
+reference-kbc = { git = "https://github.com/tylerfanelli/reference-kbc", branch = "keybroker", default-features = false, features = ["alloc"], optional = true }
 rsa = { version = "0.9.3", default-features = false, optional = true }
 sha2 = { version = "0.10.8", default-features = false, features = ["force-soft"], optional = true }
 serde_json = { version = "1.0", default-features = false, optional = true}

--- a/src/kbc.rs
+++ b/src/kbc.rs
@@ -34,7 +34,7 @@ pub enum Error {
     AutenticationFailed,
 }
 
-pub fn get_secret(workload_id: &str) -> Result<String, Error> {
+pub fn get_secret() -> Result<String, Error> {
     static PROXY_IO: SVSMIOPort = SVSMIOPort::new();
     let sp: SerialPort = SerialPort {
         driver: &PROXY_IO,
@@ -50,7 +50,7 @@ pub fn get_secret(workload_id: &str) -> Result<String, Error> {
     let priv_key = RsaPrivateKey::new(&mut rng, 2048).expect("failed to generate a key");
     let pub_key = RsaPublicKey::from(&priv_key);
 
-    let mut snp = ClientTeeSnp::new(SnpGeneration::Milan, workload_id.to_string());
+    let mut snp = ClientTeeSnp::new(SnpGeneration::Milan);
     let mut cs = ClientSession::new();
 
     let request = cs.request(&snp).unwrap();
@@ -119,7 +119,7 @@ pub fn get_secret(workload_id: &str) -> Result<String, Error> {
     info!("Attestation done");
 
     let req = Request {
-        endpoint: "/kbs/v0/key/".to_string() + workload_id,
+        endpoint: "/kbs/v0/resource".to_string(),
         method: HttpMethod::GET,
         body: json!(""),
     };

--- a/src/svsm.rs
+++ b/src/svsm.rs
@@ -491,7 +491,7 @@ pub extern "C" fn svsm_main() {
         Err(e) => log::info!("Error getting attestation report: {e:?}"),
     }
 
-    match kbc::get_secret("svsm") {
+    match kbc::get_secret() {
         Ok(secret) => log::info!("Got the secret: {secret}"),
         Err(e) => log::info!("Error doing remote attestation: {e:?}"),
     }


### PR DESCRIPTION
WIP - relies on changes to `reference-kbc` for `keybroker`.