### PR TITLE
syscall: add safety comments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,3 +112,63 @@ jobs:
         with:
           command: fmt
           args: --all -- --check --config "format_code_in_doc_comments=true"
+
+  unsafe-check:
+    name: Check of undocumented unsafe code blocks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install specified rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: '1.82.0'
+            target: x86_64-unknown-none
+            profile: minimal
+            override: true
+            components: rustfmt, rust-src, clippy
+
+      - name: Install TPM 2.0 Reference Implementation build dependencies
+        run: sudo apt install -y autoconf autoconf-archive pkg-config build-essential automake
+
+      # ubuntu-latest does not have binutils 2.39, which we need for
+      # ld to work, so build all the objects without performing the
+      # final linking step.
+      - name: Build
+        run: make FEATURES="default,enable-gdb" bin/svsm-kernel.elf stage1/stage1.o stage1/reset.o
+
+      - name: Clippy with undocumented_unsafe_blocks for PR branch
+        run: |
+          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_pr.txt
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ref: main
+
+      # ubuntu-latest does not have binutils 2.39, which we need for
+      # ld to work, so build all the objects without performing the
+      # final linking step.
+      - name: Build
+        run: make FEATURES="default,enable-gdb" bin/svsm-kernel.elf stage1/stage1.o stage1/reset.o
+
+      - name: Clippy with undocumented_unsafe_blocks for main branch
+        run: |
+          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_main.txt
+
+      - name: Compare undocumented unsafe blocks in this PR with the main branch
+        run: |
+          PR_WARNINGS=$(wc -l < clippy_warnings_pr.txt)
+          MAIN_WARNINGS=$(wc -l < clippy_warnings_main.txt)
+
+          echo "Undocumented unsafe code blocks [PR: $PR_WARNINGS main: $MAIN_WARNINGS]"
+
+          if  "$UNSAFE_PR" -gt "$UNSAFE_MAIN" ]; then
+            echo "New undocumented unsafe code blocks detected in this PR."
+            exit 1
+          fi
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,7 +114,7 @@ jobs:
           args: --all -- --check --config "format_code_in_doc_comments=true"
 
   unsafe-check:
-    name: Check of undocumented unsafe code blocks
+    name: Check unsafe blocks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -144,11 +144,17 @@ jobs:
         run: |
           cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_pr.txt
 
+      - name: Upload PR warnings artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: clippy-warnings-pr
+          path: clippy_warnings_pr.txt
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          ref: main
+          ref: ${{ github.event.pull_request.base.sha }}
 
       # ubuntu-latest does not have binutils 2.39, which we need for
       # ld to work, so build all the objects without performing the
@@ -156,19 +162,24 @@ jobs:
       - name: Build
         run: make FEATURES="default,enable-gdb" bin/svsm-kernel.elf stage1/stage1.o stage1/reset.o
 
-      - name: Clippy with undocumented_unsafe_blocks for main branch
+      - name: Clippy with undocumented_unsafe_blocks for base branch
         run: |
-          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_main.txt
+          cargo clippy --workspace --all-features --exclude packit --exclude svsm-fuzz --exclude igvmbuilder --exclude igvmmeasure -- -W clippy::undocumented_unsafe_blocks 2> clippy_warnings_base.txt
 
-      - name: Compare undocumented unsafe blocks in this PR with the main branch
+      - name: Download PR warnings artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: clippy-warnings-pr
+
+      - name: Compare undocumented unsafe blocks
         run: |
-          PR_WARNINGS=$(wc -l < clippy_warnings_pr.txt)
-          MAIN_WARNINGS=$(wc -l < clippy_warnings_main.txt)
+          PR_WARNINGS=$(grep 'missing a safety comment' clippy_warnings_pr.txt | wc -l)
+          BASE_WARNINGS=$(grep 'missing a safety comment' clippy_warnings_base.txt | wc -l)
 
-          echo "Undocumented unsafe code blocks [PR: $PR_WARNINGS main: $MAIN_WARNINGS]"
+          echo "Undocumented unsafe code blocks [PR: $PR_WARNINGS base: $BASE_WARNINGS]"
 
-          if  "$UNSAFE_PR" -gt "$UNSAFE_MAIN" ]; then
-            echo "New undocumented unsafe code blocks detected in this PR."
+          if [ "$PR_WARNINGS" -gt "$BASE_WARNINGS" ]; then
+            echo "$(($PR_WARNINGS - $BASE_WARNINGS)) new undocumented unsafe code blocks detected in this PR."
             exit 1
           fi
 

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -295,6 +295,8 @@ impl VirtAddr {
     #[verus_verify(external_body)]
     pub unsafe fn aligned_ref<'a, T>(&self) -> Option<&'a T> {
         self.is_aligned_to::<T>()
+            // SAFETY: caller should already provide safety requirements for
+            // pointers that should be null or convertible to a reference.
             .then(|| unsafe { self.as_ptr::<T>().as_ref() })
             .flatten()
     }
@@ -310,6 +312,8 @@ impl VirtAddr {
     #[verus_verify(external)]
     pub unsafe fn aligned_mut<'a, T>(&self) -> Option<&'a mut T> {
         self.is_aligned_to::<T>()
+            // SAFETY: caller should already provide safety requirements for
+            // pointers that should be null or convertible to a reference.
             .then(|| unsafe { self.as_mut_ptr::<T>().as_mut() })
             .flatten()
     }
@@ -338,6 +342,8 @@ impl VirtAddr {
     /// data pointed to by the `VirtAddr` apply here as well.
     #[verus_verify(external_body)]
     pub unsafe fn to_slice<T>(&self, len: usize) -> &[T] {
+        // SAFETY: caller should already provide safety requirements for
+        // [`core::slice::from_raw_parts`]
         unsafe { slice::from_raw_parts::<T>(self.as_ptr::<T>(), len) }
     }
 }

--- a/kernel/src/address.rs
+++ b/kernel/src/address.rs
@@ -37,7 +37,7 @@ const fn sign_extend(addr: InnerAddr) -> InnerAddr {
 pub trait Address:
     Copy + From<InnerAddr> + Into<InnerAddr> + PartialEq + Eq + PartialOrd + Ord
 {
-    // Transform the address into its inner representation for easier
+    /// Transform the address into its inner representation for easier
     /// arithmetic manipulation
     #[inline]
     #[verus_verify]

--- a/kernel/src/cpu/apic.rs
+++ b/kernel/src/cpu/apic.rs
@@ -244,6 +244,9 @@ impl LocalApic {
         // (core_remap_ca(), core_create_vcpu() or prepare_fw_launch()) so
         // they're safe to use.
         if let Ok(caa) = unsafe { calling_area.read() } {
+            // SAFETY: guest vmsa and ca are always validated before beeing updated
+            // (core_remap_ca(), core_create_vcpu() or prepare_fw_launch()) so
+            // they're safe to use.
             let _ = unsafe { calling_area.write(caa.update_no_eoi_required(0)) };
         }
         Some(calling_area)
@@ -370,6 +373,9 @@ impl LocalApic {
                         // (core_remap_ca(), core_create_vcpu() or prepare_fw_launch())
                         // so they're safe to use.
                         if let Ok(caa) = unsafe { calling_area.read() } {
+                            // SAFETY: guest vmsa and ca are always validated before beeing upated
+                            // (core_remap_ca(), core_create_vcpu() or prepare_fw_launch())
+                            // so they're safe to use.
                             if unsafe { calling_area.write(caa.update_no_eoi_required(1)).is_ok() }
                             {
                                 // Only track a pending lazy EOI if the

--- a/kernel/src/cpu/control_regs.rs
+++ b/kernel/src/cpu/control_regs.rs
@@ -94,6 +94,8 @@ bitflags! {
 pub fn read_cr0() -> CR0Flags {
     let cr0: u64;
 
+    // SAFETY: The inline assembly just reads the processors CR0 register
+    // and does not change any state.
     unsafe {
         asm!("mov %cr0, %rax",
              out("rax") cr0,
@@ -106,6 +108,9 @@ pub fn read_cr0() -> CR0Flags {
 pub fn write_cr0(cr0: CR0Flags) {
     let reg = cr0.bits();
 
+    // SAFETY: The inline assembly set the processors CR0 register with flags
+    // defined by `struct CR0Flags`.
+    // FIXME: is this enough?
     unsafe {
         asm!("mov %rax, %cr0",
              in("rax") reg,
@@ -115,6 +120,9 @@ pub fn write_cr0(cr0: CR0Flags) {
 
 pub fn read_cr2() -> usize {
     let ret: usize;
+
+    // SAFETY: The inline assembly just reads the processors CR2 register
+    // and does not change any state.
     unsafe {
         asm!("mov %cr2, %rax",
              out("rax") ret,
@@ -124,6 +132,8 @@ pub fn read_cr2() -> usize {
 }
 
 pub fn write_cr2(cr2: usize) {
+    // SAFETY: The inline assembly set the processors CR2 register.
+    // FIXME: should this function be marked unsafe?
     unsafe {
         asm!("mov %rax, %cr2",
              in("rax") cr2,
@@ -133,6 +143,9 @@ pub fn write_cr2(cr2: usize) {
 
 pub fn read_cr3() -> PhysAddr {
     let ret: usize;
+
+    // SAFETY: The inline assembly just reads the processors CR3 register
+    // and does not change any state.
     unsafe {
         asm!("mov %cr3, %rax",
              out("rax") ret,
@@ -142,6 +155,8 @@ pub fn read_cr3() -> PhysAddr {
 }
 
 pub fn write_cr3(cr3: PhysAddr) {
+    // SAFETY: The inline assembly set the processors CR3 register.
+    // FIXME: should this function be marked unsafe?
     unsafe {
         asm!("mov %rax, %cr3",
              in("rax") cr3.bits(),
@@ -179,6 +194,8 @@ bitflags! {
 pub fn read_cr4() -> CR4Flags {
     let cr4: u64;
 
+    // SAFETY: The inline assembly just reads the processors CR4 register
+    // and does not change any state.
     unsafe {
         asm!("mov %cr4, %rax",
              out("rax") cr4,
@@ -191,6 +208,9 @@ pub fn read_cr4() -> CR4Flags {
 pub fn write_cr4(cr4: CR4Flags) {
     let reg = cr4.bits();
 
+    // SAFETY: The inline assembly set the processors CR4 register with flags
+    // defined by `struct CR4Flags`.
+    // FIXME: is this enough?
     unsafe {
         asm!("mov %rax, %cr4",
              in("rax") reg,

--- a/kernel/src/cpu/cpuid.rs
+++ b/kernel/src/cpu/cpuid.rs
@@ -55,6 +55,9 @@ impl CpuidResult {
         let mut result_ebx: u32;
         let mut result_ecx: u32;
         let mut result_edx: u32;
+        // SAFETY: Inline assembly to execute the CPUID instruction.
+        // Input registers (EAX, ECX) and output registers (EAX, EBX, ECX, EDX)
+        // are safely managed.
         unsafe {
             asm!("push %rbx",
                  "cpuid",

--- a/kernel/src/cpu/extable.rs
+++ b/kernel/src/cpu/extable.rs
@@ -20,25 +20,25 @@ struct ExceptionTableEntry {
 }
 
 fn check_exception_table(rip: VirtAddr) -> VirtAddr {
-    unsafe {
-        let ex_table_start = VirtAddr::from(&raw const exception_table_start);
-        let ex_table_end = VirtAddr::from(&raw const exception_table_end);
-        let mut current = ex_table_start;
+    let ex_table_start = VirtAddr::from(&raw const exception_table_start);
+    let ex_table_end = VirtAddr::from(&raw const exception_table_end);
+    let mut current = ex_table_start;
 
-        loop {
-            let addr = current.as_ptr::<ExceptionTableEntry>();
+    loop {
+        // SAFETY: `current` is guaranteed to be a valid address within the
+        // exception table.
+        let addr = unsafe { &*current.as_ptr::<ExceptionTableEntry>() };
 
-            let start = (*addr).start;
-            let end = (*addr).end;
+        let start = addr.start;
+        let end = addr.end;
 
-            if rip >= start && rip < end {
-                return end;
-            }
+        if rip >= start && rip < end {
+            return end;
+        }
 
-            current = current + mem::size_of::<ExceptionTableEntry>();
-            if current >= ex_table_end {
-                break;
-            }
+        current = current + mem::size_of::<ExceptionTableEntry>();
+        if current >= ex_table_end {
+            break;
         }
     }
 
@@ -46,23 +46,23 @@ fn check_exception_table(rip: VirtAddr) -> VirtAddr {
 }
 
 pub fn dump_exception_table() {
-    unsafe {
-        let ex_table_start = VirtAddr::from(&raw const exception_table_start);
-        let ex_table_end = VirtAddr::from(&raw const exception_table_end);
-        let mut current = ex_table_start;
+    let ex_table_start = VirtAddr::from(&raw const exception_table_start);
+    let ex_table_end = VirtAddr::from(&raw const exception_table_end);
+    let mut current = ex_table_start;
 
-        loop {
-            let addr = current.as_ptr::<ExceptionTableEntry>();
+    loop {
+        // SAFETY: `current` is guaranteed to be a valid address within the
+        // exception table.
+        let addr = unsafe { &*current.as_ptr::<ExceptionTableEntry>() };
 
-            let start = (*addr).start;
-            let end = (*addr).end;
+        let start = addr.start;
+        let end = addr.end;
 
-            log::info!("Extable Entry {:#018x}-{:#018x}", start, end);
+        log::info!("Extable Entry {:#018x}-{:#018x}", start, end);
 
-            current = current + mem::size_of::<ExceptionTableEntry>();
-            if current >= ex_table_end {
-                break;
-            }
+        current = current + mem::size_of::<ExceptionTableEntry>();
+        if current >= ex_table_end {
+            break;
         }
     }
 }

--- a/kernel/src/cpu/idt/svsm.rs
+++ b/kernel/src/cpu/idt/svsm.rs
@@ -100,6 +100,7 @@ pub fn idt_init() {
     // Set IST vectors
     init_ist_vectors();
 
+    // SAFETY:
     // Capture an address that can be used by assembly code to read the #HV
     // doorbell page.  The address of each CPU's doorbell page may be
     // different, but the address of the field in the PerCpu structure that
@@ -228,15 +229,21 @@ extern "C" fn ex_handler_control_protection(ctxt: &mut X86ExceptionContext, _vec
         code @ (NEAR_RET | FAR_RET_IRET) => {
             // Read the return address on the normal stack.
             let ret_ptr: GuestPtr<u64> = GuestPtr::new(VirtAddr::from(ctxt.frame.rsp));
+            // SAFETY: `rsp` should be a valid guest address filled by the CPU
+            // in the X86InterruptFrame
             let ret = unsafe { ret_ptr.read() }.expect("Failed to read return address");
 
             // Read the return address on the shadow stack.
             let prev_rssp_ptr: GuestPtr<u64> = GuestPtr::new(VirtAddr::from(ctxt.ssp));
+            // SAFETY: `ssp` should be a valid guest address filled by the CPU
+            // in the X86ExceptionContext
             let prev_rssp = unsafe { prev_rssp_ptr.read() }
                 .expect("Failed to read address of previous shadow stack pointer");
             // The offset to the return pointer is different for RET and IRET.
             let offset = if code == NEAR_RET { 0 } else { 8 };
             let ret_ptr: GuestPtr<u64> = GuestPtr::new(VirtAddr::from(prev_rssp + offset));
+            // SAFETY: `ssp` should be a valid guest address filled by the CPU
+            // in the X86ExceptionContext
             let ret_on_ssp =
                 unsafe { ret_ptr.read() }.expect("Failed to read return address on shadow stack");
 

--- a/syscall/src/call.rs
+++ b/syscall/src/call.rs
@@ -20,6 +20,9 @@ macro_rules! syscall {
             #[allow(dead_code)]
             pub unsafe fn $name($a: u64, $($b: u64, $($c: u64, $($d: u64, $($e: u64, $($f: u64)?)?)?)?)?) -> Result<u64, SysCallError> {
                 let mut ret = $a;
+                // SAFETY: This block is required to perform a raw system call.
+                // The caller must ensure that the syscall number and arguments
+                // are valid.
                 unsafe {
                     asm!(
                         "int 0x80",

--- a/syscall/src/class1.rs
+++ b/syscall/src/class1.rs
@@ -19,6 +19,7 @@ impl Obj for FsObjHandle {
 }
 
 pub fn opendir(path: &CStr) -> Result<FsObjHandle, SysCallError> {
+    // SAFETY: SYS_OPENDIR is supported syscall number by the svsm kernel.
     unsafe {
         syscall1(SYS_OPENDIR, path.as_ptr() as u64)
             .map(|ret| FsObjHandle(ObjHandle::new(ret as u32)))
@@ -26,6 +27,7 @@ pub fn opendir(path: &CStr) -> Result<FsObjHandle, SysCallError> {
 }
 
 pub fn readdir(fs: &FsObjHandle, dirents: &mut [DirEnt]) -> Result<usize, SysCallError> {
+    // SAFETY: SYS_READDIR is supported syscall number by the svsm kernel.
     unsafe {
         syscall3(
             SYS_READDIR,

--- a/syscall/src/obj.rs
+++ b/syscall/src/obj.rs
@@ -36,6 +36,7 @@ pub trait Obj {
 
 impl Drop for ObjHandle {
     fn drop(&mut self) {
+        // SAFETY: SYS_CLOSE is supported syscall number by the svsm kernel.
         unsafe {
             let _ = syscall1(SYS_CLOSE, self.0.into());
         }


### PR DESCRIPTION
Add safety comments for the inline assembly in the syscall macro, and
in some unsafe blocks to wrap syscalls.

Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>