### PR TITLE
github/workflows: use nightly toolchain for "Format doctests"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,7 @@ jobs:
         run: echo "" > release/src/git_version.rs
 
       - name: Format doctests
-        run: cargo fmt --all -- --check --config "format_code_in_doc_comments=true"
+        run: cargo +nightly fmt --all -- --check --config "format_code_in_doc_comments=true"
 
   # Check for new undocumented unsafe blocks. This is to prevent them from
   # growing before we add comments for all of them and manage to enable


### PR DESCRIPTION
We have a pipeline with nightly toolchain to check the formatting of documentation, but lately the CI fails and it seems we were running `cargo fmt` on the stable toolchain.

Let's explicate the use of the nightly toolchain.

## Summary by Sourcery

CI:
- Prefix the cargo fmt invocation with +nightly in the Format doctests step of the GitHub Actions workflow