### PR TITLE
Documentation: update the mailing list address

### DIFF
--- a/Documentation/docs/developer/CONTRIBUTING.md
+++ b/Documentation/docs/developer/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Submissions to the project are accepted via pull-requests on
 GitHub against this repository: [https://github.com/coconut-svsm/svsm](https://github.com/coconut-svsm/svsm)
 
 Patches may also be sent to the development mailing list
-(svsm-devel@coconut-svsm.dev) for review.
+(coconut-svsm@lists.linux.dev) for review.
 
 Patch Format
 ------------

--- a/Documentation/docs/index.md
+++ b/Documentation/docs/index.md
@@ -22,10 +22,12 @@ and in-progress work items for the COCONUT-SVSM project as well as the first
 principles applied when making design decisions.
 
 ## Community
-Development discussions happen on the [project mailing
-list](https://mail.8bytes.org/cgi-bin/mailman/listinfo/svsm-devel)
-(svsm-devel@coconut-svsm.dev). Regular development calls are scheduled via the
-mailing list.
+Development discussions happen on the project mailing list:
+- address: coconut-svsm@lists.linux.dev
+- archive: https://lore.kernel.org/coconut-svsm/
+- subscription/unsubscription: https://subspace.kernel.org/lists.linux.dev.html
+
+Regular development calls are scheduled via the mailing list.
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ Information about COCONUT-SVSM can be found on at the
 Community
 ---------
 
-Development discussions happen on the
-[project mailing list](https://mail.8bytes.org/cgi-bin/mailman/listinfo/svsm-devel)
-(svsm-devel@coconut-svsm.dev). Regular development calls are scheduled via the
-mailing list.
+Development discussions happen on the project mailing list:
+- address: coconut-svsm@lists.linux.dev
+- archive: https://lore.kernel.org/coconut-svsm/
+- subscription/unsubscription: https://subspace.kernel.org/lists.linux.dev.html
+
+Regular development calls are scheduled via the mailing list.
 
 Reporting Bugs
 --------------


### PR DESCRIPTION
We are shutting down the old mailing list, update all references to the mailing list in our documentation.

## Summary by Sourcery

Documentation:
- Replace old svsm-devel mailing list references in index.md, README.md, and CONTRIBUTING.md with the new coconut-svsm@lists.linux.dev address and corresponding archive and subscription URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated mailing list contact information and archive links in the contributing guidelines, main documentation, and README.
  - Clarified and expanded details on how to join, contact, and manage mailing list subscriptions for the community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->