### PR TITLE
build: Remove doctests from test_in_svsm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,9 @@ bin/svsm-kernel.elf: bin
 	objcopy -O elf64-x86-64 --strip-unneeded ${SVSM_KERNEL_ELF} $@
 
 bin/test-kernel.elf: bin
-	LINK_TEST=1 cargo +nightly test --package svsm ${CARGO_ARGS} ${SVSM_ARGS_TEST} \
+# RUSTDOC=true removes doctests, which is necessary as they do not work with
+# custom test runners. See https://github.com/coconut-svsm/svsm/issues/705.
+	RUSTDOC=true LINK_TEST=1 cargo +nightly test --package svsm ${CARGO_ARGS} ${SVSM_ARGS_TEST} \
 		--target=x86_64-unknown-none \
 		--config 'target.x86_64-unknown-none.runner=["sh", "-c", "cp $$0 ../${TEST_KERNEL_ELF}"]'
 	objcopy -O elf64-x86-64 --strip-unneeded ${TEST_KERNEL_ELF} bin/test-kernel.elf


### PR DESCRIPTION
Doctests do not work with custom test frameworks, so they cannot be included in the test_in_svsm build. See
https://github.com/coconut-svsm/svsm/issues/705 for more details.

## Summary by Sourcery

Build:
- Set RUSTDOC=true in the Makefile test-kernel target to remove doctests from the svsm test build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test command to disable Rust documentation tests during kernel testing for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->