### PR TITLE
Revert "Makefile: Do not enable vtpm for Linux test runners"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifneq ($(FEATURES),)
 SVSM_ARGS += --features ${FEATURES}
 endif
 
-FEATURES_TEST ?= virtio-drivers
+FEATURES_TEST ?= vtpm,virtio-drivers
 SVSM_ARGS_TEST += --no-default-features
 ifneq ($(FEATURES_TEST),)
 SVSM_ARGS_TEST += --features ${FEATURES_TEST}

--- a/libtcgtpm/build.rs
+++ b/libtcgtpm/build.rs
@@ -27,6 +27,7 @@ fn main() {
         .use_core()
         .clang_arg("-Wno-incompatible-library-redeclaration")
         .clang_arg("-isystemdeps/libcrt/include/")
+        .clang_arg("-fno-pie") // libcrt.h hides symbols if pie is enabled
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .unwrap_or_else(|_| panic!("Unable to generate bindings for deps/libtcgtpm.h"));


### PR DESCRIPTION
This reverts commit f9ebd8953cfe64cc088cbbff7b2f301c3d667048.

## Summary by Sourcery

Build:
- Restore vtpm in FEATURES_TEST by undoing the previous removal in the Makefile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the default test configuration to enable both "vtpm" and "virtio-drivers" features during test builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->