### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS file for COCONUT-SVSM
+
+# Technical Steering Committee (TSC)
+# Joerg Roedel, Jon Lange, Peter Fang, Stefano Garzarella
+* joerg.roedel@amd.com jlange@microsoft.com peter.fang@intel.com sgarzare@redhat.com
+
+# Subsystem Maintainers


### PR DESCRIPTION
Add a CODEOWNERS file with the Technical Steering Committee members as default code owners for the entire repository, following the new policy added by https://github.com/coconut-svsm/governance/pull/81

An empty section for subsystem maintainers has been added and can be populated in future commits.